### PR TITLE
ccp: support s3 to http accel

### DIFF
--- a/accel.go
+++ b/accel.go
@@ -200,6 +200,9 @@ func (d *Disk) ReadAt(p []byte, off int64) (n int, err error) {
 	n, err = d.File.ReadAt(p, off)
 	if err != nil {
 		if err == io.EOF {
+			// This file has no way of knowing if its really EOF or not
+			// if the writer is slow, it will say this but the writer might
+			// still be doing writing in between.
 			return n, nil
 		}
 	}

--- a/accel.go
+++ b/accel.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"github.com/as/log"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	s3 "github.com/aws/aws-sdk-go/service/s3"
+)
+
+var sema = make(chan bool, 32)
+
+func (g *S3) Sign(uri string) (string, int, error) {
+	if !g.ensure() {
+		return "", 0, g.err
+	}
+	gc, _ := g.regionize(uri)
+	u := parseURL(uri)
+	sig, _ := gc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: &u.Host,
+		Key:    &u.Path,
+	})
+	su, _ := sig.Presign(72 * time.Hour)
+	size, err := httpsize(su)
+	if !*secure && strings.HasPrefix(su, "https") {
+		su = "http" + strings.TrimPrefix(su, "https")
+	}
+	log.Info.F("http fast path for %d byte file %q: %v", size, uri, err)
+	return su, size, err
+}
+
+func parseURL(s string) url.URL {
+	if u, _ := url.Parse(s); u != nil {
+		return *u
+	}
+	return url.URL{}
+}
+
+func (f HTTP) fastopen(file string) (io.ReadCloser, error) {
+	f.ensure()
+	size, err := httpsize(file)
+	if err != nil {
+		return nil, err
+	}
+	if size == 0 {
+		return nil, io.EOF
+	}
+	fi := File{Len: size}
+	return &fi, fi.Download(file)
+}
+
+type File struct {
+	Len   int
+	BS, R int
+	Block []Store
+}
+
+type Store interface {
+	io.ReaderAt
+	io.Closer
+	io.Writer
+}
+
+func (f *File) Download(dir string) error {
+	f.Len, _ = httpsize(dir)
+	if f.Len == 0 {
+		return fmt.Errorf("unknown file size")
+	}
+	nw := f.Len / *partsize
+	if nw == 0 {
+		return fmt.Errorf("file too small")
+	}
+	f.BS = f.Len / nw
+	f.Block = make([]Store, nw)
+	for i := range f.Block {
+		if i == 0 {
+			f.Block[i] = &Block{}
+		} else {
+			s, err := makedisk(i)
+			if err != nil {
+				return err
+			}
+			f.Block[i] = s
+		}
+	}
+	for i := 0; i < nw; i++ {
+		go f.work(dir, i, "")
+	}
+	return nil
+}
+
+func (f *File) work(dir string, block int, _ string) {
+	r, _ := http.NewRequest("GET", dir, nil)
+	sp := block * f.BS
+	ep := sp + f.BS
+	if ep > f.Len {
+		ep = f.Len
+	}
+	if block > 0 {
+		// NOTE(as): Sleep sort the workers so they take items from
+		// the semaphore in FIFO order.
+		time.Sleep(100 * time.Millisecond * time.Duration(block))
+		sema <- true
+		defer func() {
+			<-sema
+		}()
+	}
+	log.Debug.F("start %d", block)
+	r.Header.Add("Range", fmt.Sprintf("bytes=%d-%d", block*f.BS, ep-1))
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		panic(err)
+	}
+	io.Copy(f.Block[block], resp.Body)
+	resp.Body.Close()
+}
+
+func (f *File) Close() (err error) {
+	return
+}
+
+func (f *File) Read(p []byte) (n int, err error) {
+	block := f.R / f.BS
+	seek := f.R % f.BS
+	if block >= len(f.Block) {
+		return 0, io.EOF
+	}
+
+	n, err = f.Block[block].ReadAt(p, int64(seek))
+
+	f.R += int(n)
+	if f.R >= f.Len {
+		err = io.EOF
+	}
+	next := f.R / f.BS
+	if next > block {
+		f.Block[block].Close()
+	}
+	return
+}
+
+type Block struct {
+	sync.Mutex
+	Data []byte
+}
+
+func (b *Block) Close() error {
+	log.Debug.F("closing block")
+	b.Data = nil
+	return nil
+}
+
+func (b *Block) Write(p []byte) (n int, err error) {
+	b.Lock()
+	b.Data = append(b.Data, p...)
+	b.Unlock()
+	return len(p), nil
+}
+func (b *Block) ReadAt(p []byte, off int64) (n int, err error) {
+	at := int(off)
+	b.Lock()
+	defer b.Unlock()
+	if at >= len(b.Data) {
+		return 0, nil
+	}
+	return copy(p, b.Data[at:]), nil
+}
+
+func makedisk(n int) (*Disk, error) {
+	fd, err := os.CreateTemp(*tmp, fmt.Sprintf("ccp*-%d", n))
+	if err != nil {
+		return nil, err
+	}
+	log.Debug.F("created temp file %s", fd.Name())
+	return &Disk{Name: fd.Name(), File: fd}, nil
+}
+
+type Disk struct {
+	Name string
+	*os.File
+}
+
+func (d *Disk) ReadAt(p []byte, off int64) (n int, err error) {
+	n, err = d.File.ReadAt(p, off)
+	if err != nil {
+		if err == io.EOF {
+			return n, nil
+		}
+	}
+	return
+}
+func (d *Disk) Close() error {
+	err := d.File.Close()
+	os.Remove(d.Name)
+	log.Debug.F("delete file %q", d.Name)
+	return err
+}

--- a/fs.go
+++ b/fs.go
@@ -21,13 +21,18 @@ import (
 )
 
 var (
+	tmp      = flag.String("tmp", os.TempDir(), "temporary directory location")
+	partsize = flag.Int("partsize", 128*1024*1024, "temporary file partition size")
+	secure   = flag.Bool("secure", false, "disable https to http downgrade when using bucket optimizations")
+	slow     = flag.Bool("slow", false, "disable parallelism for same-file downloads using temp files (see tmp and partsize)")
+
 	bs       = flag.Int("bs", 2048, "block size for copy operation")
 	dry      = flag.Bool("dry", false, "print (and unroll) ccp commands only; no I/O ops")
 	test     = flag.Bool("test", false, "open and create files, but do not read or copy data")
 	quiet    = flag.Bool("q", false, "dont print any progress output")
 	flaky    = flag.Bool("flaky", false, "treat i/o errors as non-fatal")
 	debug    = flag.Bool("debug", false, "print debug logs")
-	deadband = flag.Duration("deadband", 20*time.Second, "for copies, the non-cumulative duration of no io in the process (read+write) after which ccp emits a fatal error (zero means no timeout)")
+	deadband = flag.Duration("deadband", 60*time.Second, "for copies, the non-cumulative duration of no io in the process (read+write) after which ccp emits a fatal error (zero means no timeout)")
 
 	ls = flag.Bool("ls", false, "list the source files or dirs")
 

--- a/fs_http.go
+++ b/fs_http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -20,11 +21,48 @@ func (g *HTTP) ensure() bool {
 
 func (g *HTTP) List(dir string) (file []Info, err error) {
 	u := uri(dir)
+	size, err := httpsize(dir)
+	return []Info{{URL: &u, Size: size}}, err
 	//curl -v -H 'Range: bytes=0-0'  http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
-	return []Info{{URL: &u}}, nil
+}
+
+func httpsize(dir string) (int, error) {
+	r, err := http.NewRequest("GET", dir, nil)
+	if err != nil {
+		return 0, err
+	}
+	r.Header.Add("Range", "bytes=0-0")
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil || resp.StatusCode/100 > 3 {
+		if resp.StatusCode == 416 {
+			return 0, nil
+		}
+		if err == nil {
+			return 0, fmt.Errorf("http: %s", resp.Status)
+		}
+		return 0, err
+	}
+	go func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	a, b, size := 0, 0, 0
+	_, err = fmt.Sscanf(resp.Header.Get("Content-Range"), "bytes %d-%d/%d", &a, &b, &size)
+	return size, err
 }
 
 func (f HTTP) Open(file string) (io.ReadCloser, error) {
+	if *slow {
+		return f.open(file)
+	}
+	r, err := f.fastopen(file)
+	if err != nil {
+		return f.open(file)
+	}
+	return r, err
+}
+
+func (f HTTP) open(file string) (io.ReadCloser, error) {
 	f.ensure()
 	req, _ := http.NewRequestWithContext(f.ctx, "GET", file, nil)
 	resp, err := http.DefaultClient.Do(req)

--- a/fs_s3.go
+++ b/fs_s3.go
@@ -107,7 +107,7 @@ func (g *S3) Open(file string) (io.ReadCloser, error) {
 	}
 	gc, _ := g.regionize(file)
 	su, _, err := g.Sign(file)
-	log.Printf("upgrade %q -> %q: %v", file, su, err)
+	log.Debug.F("upgrade %q -> %q: %v", file, su, err)
 	if err == nil {
 		return HTTP{}.Open(su)
 	}

--- a/fs_s3.go
+++ b/fs_s3.go
@@ -106,6 +106,11 @@ func (g *S3) Open(file string) (io.ReadCloser, error) {
 		return nil, g.err
 	}
 	gc, _ := g.regionize(file)
+	su, _, err := g.Sign(file)
+	log.Printf("upgrade %q -> %q: %v", file, su, err)
+	if err == nil {
+		return HTTP{}.Open(su)
+	}
 	u := uri(file)
 	o, err := gc.GetObject(&s3.GetObjectInput{
 		Bucket: &u.Host,


### PR DESCRIPTION
By default, ccp will now download http and https files larger than 128MiB in parallel by relying on temp files. This can be disabled by using ccp -slow. The partition size can be changed from 128MiB with ccp -partsize and the temp folder can be changed with ccp -tmp or by setting TEMPDIR

The algorithm that accelerates http downloads preserves the streaming flow of ccp, and should not require any modifications in scripts for proper use.

Another optimization for s3 is to drop https in favor for http. If applicable, all s3 file inputs are presigned and stripped to their http equivalent URLs. This too can be disabled with ccp -secure